### PR TITLE
Adiciona responsividade a barra de navegação e mudança de estilo

### DIFF
--- a/frontend/src/components/NavigationBar.vue
+++ b/frontend/src/components/NavigationBar.vue
@@ -2,7 +2,7 @@
   <div>
     <v-app-bar flat fixed>
       <v-app-bar-nav-icon
-        class="hidden-sm-and-up"
+        class="hidden-md-and-up"
         @click.stop="drawer = !drawer"
       ></v-app-bar-nav-icon>
       <v-toolbar-title><b class="title">Transites</b></v-toolbar-title>
@@ -17,12 +17,7 @@
         hide-details
         prepend-inner-icon="mdi-magnify"
       ></v-text-field>
-      <v-btn
-        class="hidden-sm-and-down"
-        rounded="lg"
-        prepend-icon="mdi-tune"
-        variant="flat"
-      >
+      <v-btn class="hidden-sm-and-down" rounded="lg" prepend-icon="mdi-tune" variant="flat">
         Busca avançada
       </v-btn>
     </v-app-bar>
@@ -37,6 +32,6 @@
 export default {
   data: () => ({
     drawer: false
-  }),
+  })
 }
 </script>

--- a/frontend/src/components/NavigationBar.vue
+++ b/frontend/src/components/NavigationBar.vue
@@ -2,6 +2,7 @@
   <div>
     <v-app-bar flat fixed>
       <v-app-bar-nav-icon
+        class="hidden-sm-and-up"
         @click.stop="drawer = !drawer"
       ></v-app-bar-nav-icon>
       <v-toolbar-title><b class="title">Transites</b></v-toolbar-title>

--- a/frontend/src/components/NavigationBar.vue
+++ b/frontend/src/components/NavigationBar.vue
@@ -18,8 +18,7 @@
         prepend-inner-icon="mdi-magnify"
       ></v-text-field>
       <v-btn
-        class="text-white hidden-sm-and-down"
-        color="var(--transites-red)"
+        class="hidden-sm-and-down"
         rounded="lg"
         prepend-icon="mdi-tune"
         variant="flat"
@@ -39,17 +38,5 @@ export default {
   data: () => ({
     drawer: false
   }),
-  computed: {
-    isMobile() {
-      return this.$vuetify.breakpoint.mdAndDown
-    }
-  }
 }
 </script>
-
-<style>
-.title {
-  color: var(--transites-red);
-  font-size: 30px;
-}
-</style>

--- a/frontend/src/components/NavigationBar.vue
+++ b/frontend/src/components/NavigationBar.vue
@@ -1,18 +1,54 @@
 <template>
-  <v-toolbar>
-    <v-app-bar-nav-icon></v-app-bar-nav-icon>
-    <v-toolbar-title>Transites</v-toolbar-title>
+  <div>
+    <v-app-bar flat fixed>
+      <v-app-bar-nav-icon
+        @click.stop="drawer = !drawer"
+      ></v-app-bar-nav-icon>
+      <v-toolbar-title><b class="title">Transites</b></v-toolbar-title>
 
-    <v-spacer></v-spacer>
+      <v-spacer></v-spacer>
 
-    <v-text-field
-      clearable
-      rounded
-      variant="solo"
-      hide-details
-      prepend-inner-icon="mdi-magnify"
-    ></v-text-field>
-
-    <v-btn rounded="lg" prepend-icon="mdi-tune" variant="flat"> Busca avançada </v-btn>
-  </v-toolbar>
+      <v-text-field
+        class="hidden-sm-and-down"
+        clearable
+        rounded
+        variant="solo"
+        hide-details
+        prepend-inner-icon="mdi-magnify"
+      ></v-text-field>
+      <v-btn
+        class="text-white hidden-sm-and-down"
+        color="var(--transites-red)"
+        rounded="lg"
+        prepend-icon="mdi-tune"
+        variant="flat"
+      >
+        Busca avançada
+      </v-btn>
+    </v-app-bar>
+    <v-navigation-drawer v-model="drawer" temporary>
+      <v-text-field label="Pesquisa"></v-text-field>
+      <v-btn>Busca Avançada</v-btn>
+    </v-navigation-drawer>
+  </div>
 </template>
+
+<script>
+export default {
+  data: () => ({
+    drawer: false
+  }),
+  computed: {
+    isMobile() {
+      return this.$vuetify.breakpoint.mdAndDown
+    }
+  }
+}
+</script>
+
+<style>
+.title {
+  color: var(--transites-red);
+  font-size: 30px;
+}
+</style>


### PR DESCRIPTION
Este PR contém mudanças na responsividade para telas pequenas, o acréscimo de um navigation-drawer com pesquisa e busca avançada.

Telas grandes:

![Captura de tela de 2023-10-23 17-44-58](https://github.com/Transites/monorepo/assets/61715930/2c1fa183-ad0c-407e-b8de-801d5cffc6b5)

Telas pequenas:

![Captura de tela de 2023-10-23 18-00-02](https://github.com/Transites/monorepo/assets/61715930/5f2e6b3e-660d-43a2-a5af-38b8c5f38c8f)

Ao clicar no drawer:

![Captura de tela de 2023-10-23 17-59-26](https://github.com/Transites/monorepo/assets/61715930/a62a3e2a-710f-4bfc-a713-5975c24e6118)

